### PR TITLE
Update cppman.nvim plugin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install using packer. Note that [nui.nvim](https://github.com/MunifTanjim/nui.nv
 ```lua
 -- cppman
 use {
-	"~/code/vim/cppman.nvim",
+	'madskjeldgaard/cppman.nvim',
 	requires = {
 		{ 'MunifTanjim/nui.nvim' }
 	},


### PR DESCRIPTION
Change cppman.nvim plugin path from a local path to a Packer supported GitHub 'username/repo' path (e.g., 'madskjeldgaard/cppman.nvim').