### PR TITLE
Always use the first search result

### DIFF
--- a/lua/cppman.lua
+++ b/lua/cppman.lua
@@ -19,8 +19,11 @@ local function reload(manwidth, word_to_search)
 
 	vim.api.nvim_buf_set_lines(0, 0, -1, true, {})
 
-	local cmd = string.format([[0r! cppman --force-columns %s '%s' ]], manwidth, word_to_search)
+	-- always select the first result
+	local cmd = string.format([[ 0r! echo 1 | cppman --force-columns %s '%s' ]], manwidth, word_to_search)
 	vim.cmd(cmd) -- Set buffer with cppman contents
+
+	vim.cmd("silent! 0,/Please enter the selection:/-1d|s/Please enter the selection: //e") -- Remove search results
 	vim.cmd("0") -- Go to top of document
 
 	vim.bo.ro = true


### PR DESCRIPTION
Fixes #4 by always selecting the first search result and clearing the extra search output from the buffer. This might not be the way you want to do things in the long term - it would be awesome if this became interactive from within neovim, but this is a workaround for now to preserve previous behaviour.